### PR TITLE
Remove enhance button for img2img and controlnet

### DIFF
--- a/src/events/button.js
+++ b/src/events/button.js
@@ -97,6 +97,15 @@ export default {
 		}
 
 		if (interaction.customId === 'enhance') {
+			if (parameters.hasOwnProperty('image') || parameters.hasOwnProperty('controlnet-image')) {
+				// enhance button is disabled for im2img and controlnet for now.
+				// for safety, let's respond with a message for previously added enhance buttons for these type of generations.
+				return interaction.reply({
+					content: getLocalizedText(`enhance temporarily disabled`, interaction.locale),
+					ephemeral: true
+				})
+			} 
+
 			const [title, scaleLabel, denoiseLabel] = 
 				[
 					getLocalizedText(`enhance image modal title`, interaction.locale),

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -10,5 +10,6 @@
 	"enhance image scale field label": "Scale (value from 1 to 10)",
 	"enhance image denoise field label": "Denoise (value from 0 to 1)",
 	"enhance image invalid scale": "Scale value must be a number from 1 to 10.",
-	"enhance image invalid denoise": "Denoise value must be a number from 0 to 1."
+	"enhance image invalid denoise": "Denoise value must be a number from 0 to 1.",
+	"enhance temporarily disabled": "The enhance button is temporarily disabled for the img2img and controlnet generations, sorry!"
 }

--- a/src/locale/pt-BR.json
+++ b/src/locale/pt-BR.json
@@ -10,5 +10,6 @@
 	"enhance image scale field label": "Escala (valor de 1 a 10)",
 	"enhance image denoise field label": "Denoise (valor de 0 a 1)",
 	"enhance image invalid scale": "Valor de escala deve ser um número de 1 a 10.",
-	"enhance image invalid denoise": "Valor do denoise deve ser um número de 0 a 1."
+	"enhance image invalid denoise": "Valor do denoise deve ser um número de 0 a 1.",
+	"enhance temporarily disabled": "O botão de ampliação está temporariamente desativado para gerações img2img e controlnet, desculpe!"
 }

--- a/src/shared/generate.js
+++ b/src/shared/generate.js
@@ -178,7 +178,7 @@ export const generate = async (interaction, parameters) => {
 				{ emoji: `1058978647043735582`, id: `edit`, style: ButtonStyle.Success, disabled: !isLastImage }
 			]
 
-			if (parameters['hr-scale'] == null) {
+			if (parameters['hr-scale'] == null && !isImg2Img && !isControlNet) {
 				generationButtons.push({ emoji: '1050092899083227166', id: 'enhance', style: ButtonStyle.Success, disabled: !isLastImage })
 			}
 


### PR DESCRIPTION
It's causing OOM crashes.
To fix this problem instead of using the `hr-scale` param, must multiply the `width` and `height` instead.

Example:
`height=500 width=500 hr-scale=2` to `height=1000 width=1000`