### PR TITLE
Log response when no models could be found

### DIFF
--- a/src/artificial intelligence/models.js
+++ b/src/artificial intelligence/models.js
@@ -5,11 +5,9 @@ const response = await fetch("http://127.0.0.1:7860/sdapi/v1/sd-models", {
 	}
 })
 
-let data = await response.json()
+const data = await response.json()
 
-if (!Array.isArray(data)) {
-	console.warn('could not get models, /v1/sd-models did not return an array. Response:\n', data)
-	data = []
-}
+const isDataAnArray = Array.isArray(data)
+console.assert(isDataAnArray, `Could not get models, /v1/sd-models did not return an array. Response:\n${data}`)
 
-export default data
+export default isDataAnArray ? data : []

--- a/src/artificial intelligence/models.js
+++ b/src/artificial intelligence/models.js
@@ -6,4 +6,8 @@ const response = await fetch("http://127.0.0.1:7860/sdapi/v1/sd-models", {
 })
 const data = await response.json()
 
+if (!Array.isArray(data)) {
+	console.log('could not get models, /v1/sd-models did not return an array. Response:\n', data);
+}
+
 export default data


### PR DESCRIPTION
If `/v1/sd-models` does not return an array of models, it will log an error and the bot will not stop.