### PR TITLE
Use Civitai API to download LoRA

### DIFF
--- a/src/artificial intelligence/models.js
+++ b/src/artificial intelligence/models.js
@@ -6,4 +6,8 @@ const response = await fetch("http://127.0.0.1:7860/sdapi/v1/sd-models", {
 })
 const data = await response.json()
 
+if (!Array.isArray(data)) {
+	console.log('could not get models, /v1/sd-models did not return an array. Response:\n', data);
+}
+
 export default data

--- a/src/commands/artificial intelligence/lora/data.js
+++ b/src/commands/artificial intelligence/lora/data.js
@@ -36,6 +36,7 @@ export default {
 						'pt-BR': 'Nome personalizado para o arquivo',
 					},
 					required: false,
+					max_length: 30
 				},
 			],
 		},

--- a/src/commands/artificial intelligence/lora/main.js
+++ b/src/commands/artificial intelligence/lora/main.js
@@ -187,12 +187,3 @@ const downloadFileFromResponse = async (res, destination, filename) => {
 		})
 	})
 }
-
-const downloadFileFromUrl = async (url, destination, filename) => {
-	const res = await fetch(url)
-	if (!res.ok) {
-		throw new Error(`Failed to fetch ${url}: ${res.statusText}`)
-	}
-
-	return downloadFileFromResponse(res, destination, filename)
-}

--- a/src/commands/artificial intelligence/lora/main.js
+++ b/src/commands/artificial intelligence/lora/main.js
@@ -24,117 +24,175 @@ export default {
 /** @param {ChatInputCommandInteraction} interaction */
 const addLora = async interaction => {
 	const url = interaction.options.getString('url', true)
+	const apiKey = config.civitaiAPIKey
 	const destination = config.loraFolderPath
+
 	let customFileName = interaction.options.getString('filename') ?? ''
 
-	// no destination path.
-	if (!destination)
+	// no destination path or api key.
+	if (!destination || !apiKey) {
+		if (!destination) console.log('no lora path set. Please set the "loraFolderPath" in the config.json')
+		if (!apiKey) console.log('no civitai apikey. Please set the "civitaiAPIKey" in the config.json')
+
 		return interaction.reply({
-			content: getLocalizedText('lora path missing', interaction.locale),
+			content: getLocalizedText('lora generic error', interaction.locale),
 			ephemeral: true,
 		})
+	}
 
-	// validate url
-	if (!url.match(/^https:\/\/civitai.com\/api\/download\/models\/(\d+)(\?.+)?/))
+	const modelIdMatch = url.match(/\/models\/(\d+)/)
+
+	// no model id found or invalid url.
+	if (!url.startsWith('https://civitai.com/') || !modelIdMatch)
 		return interaction.reply({
 			content: getLocalizedText('lora invalid link', interaction.locale),
 			ephemeral: true,
 		})
 
-	// remove characters that might be problematic when prompting
-	customFileName = customFileName?.replace(/[^a-z0-9-_]/gi, '_')
+	const modelId = modelIdMatch[1]
 
-	// check if destination folder exists, create it if not
+	await interaction.deferReply()
+
+	// get model info
+	const modelData = await fetch(`https://civitai.com/api/v1/models/${modelId}`, {
+		headers: {
+			Authorization: `Bearer ${apiKey}`,
+			'Content-Type': 'application/json',
+		},
+	})
+		.then((res) => res.json())
+		.catch((err) => {
+			console.log('could not fetch the model, error:\n', err)
+		})
+
+	if (!modelData)
+		return interaction.editReply({
+			content: getLocalizedText('lora generic error', interaction.locale),
+			ephemeral: true,
+		})
+
+	if (modelData.type !== 'LORA')
+		return interaction.editReply({
+			content: getLocalizedText('lora wrong type', interaction.locale),
+			ephemeral: true,
+		})
+
+	// get download url.
+	const downloadUrl = modelData.modelVersions[0].downloadUrl + '?token=' + apiKey
+	const downloadUrlWithoutToken = modelData.modelVersions[0].downloadUrl
+
+	// check if destination folder exists, create it if not.
 	if (!fs.existsSync(destination)) {
 		fs.mkdirSync(destination, { recursive: true })
 	}
 
-	// check if file already exists
-	const fileExist = (() => {
-		if (!customFileName) return false
+	// downloading...
+	console.log(`downloading ${modelData.name}...`)
+	console.log('url:', downloadUrlWithoutToken)
 
-		const customNameNoExt = customFileName.substring(0, customFileName.lastIndexOf('.')) || customFileName // remove extension
-		const files = fs.readdirSync(destination)
+	const downloadRes = await fetch(downloadUrl).catch((err) => {
+		console.log('failed to fetch the download link, error:\n', err)
+	})
 
-		return files.some((file) => {
-			const fileWithoutExtension = file.substring(0, file.lastIndexOf('.')) // remove extension of each file
-			return fileWithoutExtension === customNameNoExt
+	if (!downloadRes || !downloadRes.ok) {
+		if (downloadRes) console.log('failed to fetch the download link:', downloadRes.statusText)
+
+		return interaction.editReply({
+			content: getLocalizedText('lora generic error', interaction.locale),
+			ephemeral: true,
 		})
+	}
+
+	// add .safetensors if the custom file name doesn't end with .safetensors
+	if (customFileName && !customFileName.endsWith('.safetensors')) customFileName += '.safetensors'
+
+	// remove characters that might be problematic when prompting
+	customFileName = (() => {
+		if (!customFileName) return ''
+		let noExt = customFileName.replace('.safetensors', '')
+		noExt = noExt.replace(/[^a-z0-9-_]/gi, '_')
+		return noExt + '.safetensors'
 	})()
 
-	if (fileExist)
-		return interaction.reply({
+	const filename = (() => {
+		// use custom file name.
+		if (customFileName) return customFileName
+
+		// use content-disposition header
+		const fileNameFromResponse = getFileNameFromResponse(downloadRes)
+		if (fileNameFromResponse) return fileNameFromResponse
+
+		// use id
+		return `${modelId}.safetensors`
+	})()
+
+	// check if custom file name already exists in the lora folder.
+	const fileExists = (() => {
+		const files = fs.readdirSync(destination)
+		return files.includes(filename)
+	})()
+
+	if (fileExists)
+		return interaction.editReply({
 			content: getLocalizedText('lora already exist', interaction.locale),
 			ephemeral: true,
 		})
 
-	await interaction.deferReply()
+	const filePath = await downloadFileFromResponse(downloadRes, destination, filename).catch((err) => {
+		console.log('could not download the file, error:\n', err)
+	})
 
-	// download the file...
-	let fileName = ''
-
-	try {
-		fileName = await downloadFile(url, destination, customFileName)
-	} catch (err) {
+	if (!filePath)
 		return interaction.editReply({
-			content: `${getLocalizedText('lora generic error', interaction.locale)}\n> \`${err}\``,
+			content: getLocalizedText('lora generic error', interaction.locale),
 		})
-	}
+	
+	console.log('download done!')
 
-	const fileNameNoExt = fileName.replace(/\..+$/, '')
+	const fileNameWithoutExt = filename.replace('.safetensors', '')
 
-	// send successful message.
+	// done
 	interaction.editReply({
-		content: getFormattedLocalizedText('lora add success', interaction.locale, fileNameNoExt),
+		content: getFormattedLocalizedText('lora add success', interaction.locale, fileNameWithoutExt),
 	})
 }
 
-const downloadFile = async (url, destination, customFileName = '') => {
-	const response = await fetch(url)
-	if (!response.ok) {
-		throw new Error(`Failed to fetch ${url}: ${response.statusText}`)
-	}
-
-	// get filename
-	let fileName = ''
-	const contentDisposition = response.headers.get('content-disposition')
+const getFileNameFromResponse = (res) => {
+	const contentDisposition = res.headers.get('content-disposition')
 	if (contentDisposition && contentDisposition.includes('filename=')) {
-		const match = contentDisposition.match(/filename="(.+?)"/)
-		if (match) {
-			fileName = match[1]
-		}
+		const match = contentDisposition.match(/filename="(.+)"/)
+		if (match) return match[1]
 	}
 
-	if (!fileName) {
-		fileName = url.substring(url.lastIndexOf('/') + 1)
-	}
+	return ''
+}
 
-	// set custom file name
-	fileName = (() => {
-		if (!customFileName) return fileName
-		const ext = fileName.split('.').at(-1) || ''
-
-		if (customFileName.includes('.')) return customFileName
-		if (!ext) return customFileName
-		return customFileName + '.' + ext
-	})()
-
-	const filePath = path.join(destination, fileName)
+const downloadFileFromResponse = async (res, destination, filename) => {
+	const filePath = path.join(destination, filename)
 
 	const fileStream = fs.createWriteStream(filePath)
 
 	return new Promise((resolve, reject) => {
-		response.body.pipe(fileStream)
-		response.body.on('error', (err) => {
+		res.body.pipe(fileStream)
+		res.body.on('error', (err) => {
 			fs.unlink(filePath, () => {}) // delete the file async if an error occurs
 			reject(err)
 		})
 		fileStream.on('finish', () => {
-			resolve(path.basename(filePath)) // resolve file name
+			resolve(filePath) // resolve full file path
 		})
 		fileStream.on('error', (err) => {
 			fs.unlink(filePath, () => {}) // delete the file async if an error occurs
 			reject(err)
 		})
 	})
+}
+
+const downloadFileFromUrl = async (url, destination, filename) => {
+	const res = await fetch(url)
+	if (!res.ok) {
+		throw new Error(`Failed to fetch ${url}: ${res.statusText}`)
+	}
+
+	return downloadFileFromResponse(res, destination, filename)
 }

--- a/src/locale/en-US.json
+++ b/src/locale/en-US.json
@@ -12,9 +12,9 @@
 	"enhance image invalid scale": "Scale value must be a number from 1 to 10.",
 	"enhance image invalid denoise": "Denoise value must be a number from 0 to 1.",
 	"enhance temporarily disabled": "The enhance button is temporarily disabled for img2img generations, sorry!",
-	"lora path missing": "Oops, the lora folder path is not configured correctly. The person hosting me must set up `config.loraFolderPath` first!",
 	"lora invalid link": "Invalid link!",
 	"lora generic error": "Something went wrong, sorry!",
 	"lora already exist": "A LoRA by this name already exists, sorry.",
+	"lora wrong type": "The link you gave me is not a LoRA, sorry.",
 	"lora add success": "LoRA **{0}** added succesfully!"
 }

--- a/src/locale/pt-BR.json
+++ b/src/locale/pt-BR.json
@@ -12,9 +12,9 @@
 	"enhance image invalid scale": "Valor de escala deve ser um número de 1 a 10.",
 	"enhance image invalid denoise": "Valor do denoise deve ser um número de 0 a 1.",
 	"enhance temporarily disabled": "O botão de ampliação está temporariamente desativado para gerações img2img, desculpe!",
-	"lora path missing": "Ops! Parece que o caminho para baixar o LoRA não foi configurado! O moço ou moça me hosteando precisa adicionar um caminho para pasta de LoRA usando `config.loraFolderPath` primeiro!",
 	"lora invalid link": "Link inválido!",
 	"lora generic error": "Algo de errado aconteceu, desculpe!",
 	"lora already exist": "Um LoRA com esse nome já existe, desculpa.",
+	"lora wrong type": "O link que você me deu não é de um LoRA, desculpa.",
 	"lora add success": "LoRA **{0}** adicionada com sucesso!"
 }


### PR DESCRIPTION
The `/lora add` command will use the Civitai API to correctly validate if the url is a LoRA and also supports more links from civitai.

For this to work it must be added to the config.json the following keys:
`civitaiAPIKey` - a Civitai API token.
`loraFolderPath` - the path for the folder where the LoRA files will be downloaded.