### PR TITLE
add start script and auto generate config.json after install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "soph",
 			"version": "2.0.0",
+			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {
 				"discord.js": "^14.19.3"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"main": "src/main.mjs",
 	"scripts": {
 		"register": "node src/register-commands.mjs",
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"start": "node src/main.mjs",
+		"postinstall": "node setup.mjs"
 	},
 	"keywords": [],
 	"author": "",

--- a/setup.mjs
+++ b/setup.mjs
@@ -1,0 +1,22 @@
+// This file generate the config.json file after running `npm install`
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const configPath = path.join(__dirname, 'config.json')
+
+if (fs.existsSync(configPath)) {
+  // skip if already exist.
+  process.exit(0)
+}
+
+const config = {
+  token: 'ADD_YOUR_TOKEN_HERE',
+  clientId: 'ADD_YOUR_CLIENT_ID_HERE',
+}
+
+fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
+
+console.log('Config file generated in config.json')


### PR DESCRIPTION
- add `npm start` script to start the `src/main.mjs`
- add a postinstall script, it will generate a `config.json` when running the `npm install`